### PR TITLE
Allow modules without the `-module` prefix using extra option

### DIFF
--- a/src/LaravelModuleInstaller.php
+++ b/src/LaravelModuleInstaller.php
@@ -32,11 +32,10 @@ class LaravelModuleInstaller extends LibraryInstaller
 
         $extra = $this->composer->getPackage()->getExtra();
 
-        if (!$extra || empty($extra['module-dir'])) {
-            return self::DEFAULT_ROOT;
+        if ($moduleDir = ($extra['module-dir'] ?? false)) {
+            return $dir;
         }
-
-        return $extra['module-dir'];
+        return self::DEFAULT_ROOT;
     }
 
     /**
@@ -50,6 +49,10 @@ class LaravelModuleInstaller extends LibraryInstaller
      */
     protected function getModuleName(PackageInterface $package)
     {
+        if ($moduleDirName = ($extra['module-dir-name'] ?? false)) {
+            return $moduleDirName;
+        }
+        
         $name = $package->getPrettyName();
         $split = explode("/", $name);
 

--- a/src/LaravelModuleInstaller.php
+++ b/src/LaravelModuleInstaller.php
@@ -33,7 +33,7 @@ class LaravelModuleInstaller extends LibraryInstaller
         $extra = $this->composer->getPackage()->getExtra();
 
         if ($moduleDir = ($extra['module-dir'] ?? false)) {
-            return $dir;
+            return $moduleDir;
         }
         return self::DEFAULT_ROOT;
     }
@@ -49,7 +49,7 @@ class LaravelModuleInstaller extends LibraryInstaller
      */
     protected function getModuleName(PackageInterface $package)
     {
-        if ($moduleDirName = ($extra['module-dir-name'] ?? false)) {
+        if ($moduleDirName = ($package->getExtra()['module-dir-name'] ?? false)) {
             return $moduleDirName;
         }
         


### PR DESCRIPTION
Apparently there appears to be a requirement to name your repository in a specific way in order to be accepted as a Laravel module.

I've added a much more simple solution that allows to add an additional property to `composer.json` of any repository:

```json
{
    "extra": {
        "module-dir-name": "MyModuleName"
    }
}
```

Then, together with
```json
{
    "type": "laravel-module"
}
```

any repository should work.

This adds the most flexibility. I've also used the `??` operator (PHP 7+ which works for this package) to simplify the code.

PS: I coded this on Github so I didnt test it.

@nWidart possible doc update for https://nwidart.com/laravel-modules/v6/advanced-tools/publishing-modules if this gets accepted?