### PR TITLE
Direct module folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,24 @@
 
 The purpose of this package is to allow for easy installation of standalone Modules into the [Laravel Modules](https://github.com/nWidart/laravel-modules) package. This package will ensure that your module is installed into the `Modules/` directory instead of `vendor/`.
 
-You can specify an alternate directory by including a `module-dir` in the extra data in your composer.json file:
+You can specify an alternate directory by including a `module-dir` in the extra data in your app `composer.json` file:
 
     "extra": {
         "module-dir": "Custom"
     }
 
+Also you can specify exact module name in package `composer.json` before its publication:
+
+    "extra": {
+        "module-name": "blog"
+    }
+
+Here in example target folder is `Modules/Blog` (`ucfirst` for `module-name` applied).  
 
 ## Installation
 
 1. Ensure you have the `type` set to `laravel-module` in your module's `composer.json`
-2. Ensure your package is named in the convention `<namespace>/<name>-module`, for example `joshbrw/user-module` would install into `Modules/User`
+2. (Skip when package's `composer.json` contains `module-name`). Ensure your package is named in the convention `<namespace>/<name>-module`, for example `joshbrw/user-module` would install into `Modules/User`
 3. Require this package: `composer require joshbrw/laravel-module-installer`
 4. Require your bespoke module using Composer. You may want to set the constraint to `dev-master` to ensure you always get the latest version.
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vbulash/laravel-module-installer",
+    "name": "joshbrw/laravel-module-installer",
     "type": "composer-plugin",
     "license": "MIT",
     "version": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "vbulash/laravel-module-installer",
     "type": "composer-plugin",
     "license": "MIT",
+    "version": "1.0",
     "autoload": {
         "psr-4": {
             "Joshbrw\\LaravelModuleInstaller\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
-    "name": "joshbrw/laravel-module-installer",
+    "name": "vbulash/laravel-module-installer",
     "type": "composer-plugin",
     "license": "MIT",
+    "version": "1.0",
     "autoload": {
         "psr-4": {
             "Joshbrw\\LaravelModuleInstaller\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "joshbrw/laravel-module-installer",
     "type": "composer-plugin",
     "license": "MIT",
-    "version": "1.0",
     "autoload": {
         "psr-4": {
             "Joshbrw\\LaravelModuleInstaller\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "joshbrw/laravel-module-installer",
+    "name": "vbulash/laravel-module-installer",
     "type": "composer-plugin",
     "license": "MIT",
     "autoload": {

--- a/src/LaravelModuleInstaller.php
+++ b/src/LaravelModuleInstaller.php
@@ -50,6 +50,11 @@ class LaravelModuleInstaller extends LibraryInstaller
      */
     protected function getModuleName(PackageInterface $package)
     {
+        $extra = $package->getExtra();
+        if ($extra && isset($extra['module-name'])) {
+            return ucfirst($extra['module-name']);
+        }
+        
         $name = $package->getPrettyName();
         $split = explode("/", $name);
 


### PR DESCRIPTION
Hello, Josh!

Rule "extract module folder name from module package name" seems not convenient.
Example:
- I have 2 similar modules - Dashboard for App1 and Dashboard for App2. Names are identical, content - is not.
- Yes, in GitHub / Packagist I have to put 2 repositories with exact names - vbulash/app1.dashboard-module and vbulash/app2.dashboard-module. Nothing against - I can't get identical repository names.
- But after `laravel-module-installer` I see folders with names - `Modules/App1.Dashboard` and `Modules\App2.Dashboard`. Seems strange.
- More flexible folder names - `Modules\Dashboard` for both cases.

I wrote few lines of code and some short text in readme to get this behavior (in addition to your way).

Hope it is good idea.

Regards,
Valery Bulash
